### PR TITLE
FFT: Changes to defines to make emscripten happy

### DIFF
--- a/HISSTools_FFT/HISSTools_FFT_Core.h
+++ b/HISSTools_FFT/HISSTools_FFT_Core.h
@@ -80,7 +80,6 @@ namespace hisstools_fft_impl{
         return static_cast<T *>(mem);
     }
 
-
 #elif defined(__EMSCRIPTEN__)
 
     template <class T>

--- a/HISSTools_FFT/HISSTools_FFT_Core.h
+++ b/HISSTools_FFT/HISSTools_FFT_Core.h
@@ -4,15 +4,15 @@
 #include <functional>
 
 #if defined(__arm__) || defined(__arm64)
-#include <arm_neon.h>
-#include <memory.h>
-#else
-#if defined(_WIN32)
-#include <malloc.h>
-#include <intrin.h>
-#endif
-#include <emmintrin.h>
-#include <immintrin.h>
+# include <arm_neon.h>
+# include <memory.h>
+#elif defined(__APPLE__) || defined(__LINUX__) || defined(_WIN32)
+# if defined(_WIN32)
+#   include <malloc.h>
+#   include <intrin.h>
+# endif
+# include <emmintrin.h>
+# include <immintrin.h>
 #endif
 
 // Microsoft Visual Studio doesn't ever define __SSE__ so if necessary we derive it from other defines
@@ -80,6 +80,16 @@ namespace hisstools_fft_impl{
         return static_cast<T *>(mem);
     }
     
+
+#elif defined(__EMSCRIPTEN__)
+    template <class T>
+    T *allocate_aligned(size_t size)
+    {
+        void *mem;
+        posix_memalign(&mem, 16, size * sizeof(T));
+        return static_cast<T *>(mem);
+    }
+
 #elif defined(__arm__) || defined(__arm64__)
     
     template <class T>

--- a/HISSTools_FFT/HISSTools_FFT_Core.h
+++ b/HISSTools_FFT/HISSTools_FFT_Core.h
@@ -4,15 +4,15 @@
 #include <functional>
 
 #if defined(__arm__) || defined(__arm64)
-# include <arm_neon.h>
-# include <memory.h>
+#include <arm_neon.h>
+#include <memory.h>
 #elif defined(__APPLE__) || defined(__LINUX__) || defined(_WIN32)
-# if defined(_WIN32)
-#   include <malloc.h>
-#   include <intrin.h>
-# endif
-# include <emmintrin.h>
-# include <immintrin.h>
+#if defined(_WIN32)
+#include <malloc.h>
+#include <intrin.h>
+#endif
+#include <emmintrin.h>
+#include <immintrin.h>
 #endif
 
 // Microsoft Visual Studio doesn't ever define __SSE__ so if necessary we derive it from other defines
@@ -79,9 +79,10 @@ namespace hisstools_fft_impl{
         posix_memalign(&mem, SIMDLimits<T>::max_size * sizeof(T), size * sizeof(T));
         return static_cast<T *>(mem);
     }
-    
+
 
 #elif defined(__EMSCRIPTEN__)
+
     template <class T>
     T *allocate_aligned(size_t size)
     {


### PR DESCRIPTION

* don't try and import intrinsics headers (not available)
* explicitly align allocations on 16 bytes

You may not want emscripten nonsense in your nice library, of course. 

This doesn't try and use any SIMD intrinsics for WebAssembly because
* The whole thing still seems in flux, and I don't know the extent of browser support
* It's not clear that the built-ins that emscripten provides would do everything you need for this anyway  