### PR TITLE
Write to file in chunks to reduce seeking

### DIFF
--- a/AudioFile/OAudioFile.h
+++ b/AudioFile/OAudioFile.h
@@ -45,7 +45,13 @@ namespace HISSTools
         bool putU24(uint32_t value, Endianness fileEndianness);
         bool putU16(uint32_t value, Endianness fileEndianness);
         bool putU08(uint32_t value);
-        
+
+        void rawU64(uint64_t value, Endianness fileEndianness, unsigned char* bytes);
+        void rawU32(uint32_t value, Endianness fileEndianness, unsigned char* bytes);
+        void rawU24(uint32_t value, Endianness fileEndianness, unsigned char* bytes);
+        void rawU16(uint32_t value, Endianness fileEndianness, unsigned char* bytes);
+        void rawU08(uint32_t value, unsigned char* bytes);
+
         bool putPadByte();
 
         bool putExtended(double);
@@ -70,7 +76,8 @@ namespace HISSTools
         
         //  Data
 
-        std::ofstream mFile;
+        std::fstream mFile;
+        unsigned char* mBuffer;
     };
 }
 


### PR DESCRIPTION
Hello, 

Here's a crack at improving the speed of multichannel output file writes along the basis suggested in your place-holder comment. My testing hasn't been exhaustive, but I have confirmed that I can still null sum the multichannel outputs of decompositions in the FluCoMa toolkit against the original, and done a rudimentary timing comparison using the code at the bottom. 

The results are pretty stark, so maybe I've goofed in the test. This reports the average of 10 runs of writing 100k samples to files of 1,2,5,10,20 and 50 channels. 

Sample results from my machne:
|  | 1 | 2 | 5 | 10 | 20 | 50 |
|-------|--------|---------|---------|---------|--------|---------|
|before|2.50955 |618.775 |2069.17 |4702.35 |10017.4 |32646.8 |
|after|6.45916 |13.6988 |33.2955 |77.4003 |207.925 |1261.41 |

So mono performance is degraded, but all multichannel speeds are quite markedly improved. I was just hitting and hoping a bit with `std::fstream` stuff, so it's quite possible there's the scope to make it work better for mono too. 

```c++
#include <AudioFile/OAudioFile.h>

#include <vector>
#include <chrono>
#include <numeric>
#include <iostream>

int main(int argc, char* argv[])
{
  
    std::vector<uint16_t> chans{1,2,5,10,20,50};
    int numFrames = 1e5; 
    for(auto c:chans)
    {
      
      std::vector<double> durations(10);
      std::vector<float> data(1e5);
    
      for(int run = 0; run < 10; ++run)
      {
              
        HISSTools::OAudioFile file("/tmp/oaudiofiletimer.wav", HISSTools::BaseAudioFile::FileType::kAudioFileWAVE, HISSTools::BaseAudioFile::PCMFormat::kAudioFileFloat32, c, 48000);

        auto start = std::chrono::steady_clock::now();

        for (uint16_t i = 0; i < c; i++)
        {
          file.seek();
          file.writeChannel(data.data(), data.size(),i);
        }

        auto end = std::chrono::steady_clock::now();
        
        std::chrono::duration<double,std::ratio<1,1000>> elapsed = end-start;
        durations[run] = elapsed.count();
      }
        
      auto sum = std::accumulate(durations.begin(), durations.end(), 0.0);
      std::cout << sum / durations.size() << '\n';
    }
}
```