### PR TITLE
Make includes for intel intrinsics headers conditional.

### DIFF
--- a/SIMDSupport.hpp
+++ b/SIMDSupport.hpp
@@ -4,8 +4,17 @@
 
 #include <cmath>
 #include <cstdint>
+
+#if defined(__arm__) || defined(__arm64)
+#include <memory.h>
+#elif defined(__APPLE__) || defined(__linux__) || defined(_WIN32)
+#if defined(_WIN32)
+#include <malloc.h>
+#include <intrin.h>
+#endif
 #include <emmintrin.h>
 #include <immintrin.h>
+#endif
 
 #ifdef __APPLE__
 
@@ -735,4 +744,3 @@ template <int N> SIMDType<float, N> abs(const SIMDType<float, N> a)
 }
 
 #endif
-


### PR DESCRIPTION
This replicates the logic from FFT_Core to only conditionally include Intel specific intrinsics. It doesn't look like we need extra code to fall back to using scalar operations here, because that's the default position if none of AVX512, AVX or SSE are defined. 

I've not used the `arm_neon.h` include as it's not needed yet, in the absence of any hand-rolled ARM goodness. 